### PR TITLE
Quick fix for an issue with workers.getByLocation

### DIFF
--- a/lib/resources/Workers.js
+++ b/lib/resources/Workers.js
@@ -21,6 +21,7 @@ class Workers extends Resource {
       },
       getByLocation: {
         path: '/workers/location',
+        altPath: '/workers/location',
         method: 'GET',
         queryParams: true,
       },


### PR DESCRIPTION
Calls to workers.getByLocation were receiving  HttpErrors. Inspection on Onfleet logs showed that the urls were being sent as `/api/v2undefined` - this appears to be related to logic in the Methods.js block starting around line 61 - rather than editing that logic (which might have other unintended effects) I've added an "altPath" definition to the getByLocation here that allows the basic usage to function.