### PR TITLE
enable passing a baseURL param to the Onfleet class constructor

### DIFF
--- a/lib/onfleet.js
+++ b/lib/onfleet.js
@@ -27,15 +27,16 @@ resources.Webhooks = require('./resources/Webhooks');
  */
 
 class Onfleet {
-  constructor(apiKey, userTimeout, bottleneckOptions) {
+  constructor(apiKey, userTimeout, bottleneckOptions, baseURL = DEFAULT_URL) {
     if (!apiKey) {
       throw new ValidationError('Onfleet API key not found, please obtain an API key from your organization admin');
-    } if (userTimeout > 70000) {
+    } 
+    if (userTimeout > 70000) {
       throw new ValidationError('User-defined timeout has to be shorter than 70000ms');
     } else {
       this.apiKey = apiKey;
       this.api = {
-        baseUrl: `${DEFAULT_URL}${DEFAULT_PATH}/${DEFAULT_API_VERSION}`,
+        baseUrl: `${baseURL}${DEFAULT_PATH}/${DEFAULT_API_VERSION}`,
         // eslint-disable-next-line no-unneeded-ternary
         timeout: (userTimeout ? userTimeout : DEFAULT_TIMEOUT),
         headers: {


### PR DESCRIPTION
Hi James, 

I am working on a proof of concept in order to build an automation test suite for the Dashboard web app with Playwright and I want to be able to use this node wrapper in my before and after hooks but I noticed that we can't pass a baseURL to the Onfleet class in order to be able to use it in staging or locally.
