### PR TITLE
Relocate `depleted` event handler

### DIFF
--- a/lib/Methods.js
+++ b/lib/Methods.js
@@ -35,6 +35,15 @@ const wait = (ms) => {
   });
 };
 
+// On reservoir depletion, we wait 10000ms and reset the rate again (20 req/second limitation)
+limiter.on('depleted', (empty) => {
+  if (!empty) {
+    wait(constants.LIMITER_WAIT_UPON_DEPLETION).then(() => {
+      reassignRate(constants.LIMITER_RESERVOIR);
+    });
+  }
+});
+
 /**
  * The Method Factory
  * @desc configures the actual method for each CRUD operations
@@ -108,15 +117,9 @@ const Methods = (key, api, ...args) => {
     headers: api.api.headers,
     timeout: timeoutInMilliseconds,
     body: hasBody ? JSON.stringify(body) : undefined,
-  }).then((res) => {
-    // On reservoir depletion, we wait 10000ms and reset the rate again (20 req/second limitation)
-    limiter.on('depleted', (empty) => {
-      if (!empty) {
-        wait(constants.LIMITER_WAIT_UPON_DEPLETION).then(() => {
-          reassignRate(constants.LIMITER_RESERVOIR);
-        });
-      }
-    });
+  }))
+  .then((res) => {
+
     // For every request, we compare the reservoir with the remainding rate limit in the header
     limiter.currentReservoir()
       .then((reservoir) => {
@@ -129,6 +132,7 @@ const Methods = (key, api, ...args) => {
       // Return status code for deletion as the API does, else, return the body of the response
       return operations === 'DELETE' ? res.status : res.json();
     }
+
     return res.json().then((error) => {
       // Throws custom error according to errorCode
       const errorCode = error.message.error;
@@ -150,9 +154,11 @@ const Methods = (key, api, ...args) => {
       // All others, throw general HTTP error
       throw new HttpError(errorInfo[0], errorInfo[1], errorInfo[2], errorInfo[3]);
     });
-  }).catch((error) => {
+
+  })
+  .catch((error) => {
     throw (error);
-  }));
+  });
 };
 
 module.exports = Methods;


### PR DESCRIPTION
<!---
Loosely inspired by https://keepachangelog.com/en/1.1.0/.

Please add items to their respective section and delete empty sections.
- Added: for new features
- Changed: for changes in existing functionality
- Deprecated: for soon-to-be removed features
- Removed: for now removed features
- Fixed: for any bug fixes
- Security: in case of vulnerabilities
Ideally, each item here will be added into the upcoming release.

DO NOT post internal Onfleet links (e.g. Jira/Confluence) –this is a public space.
-->

**Describe the solution**
In order to avoid memory leaks that are apparently caused by allocating multiple event handlers, the `depleted` event handler for `Bottleneck`'s `limiter` now lives outside `schedule`'s promise.

---

**Changed**
- Relocate `depleted` event handler