### PR TITLE
docs: Fixed create method example on README files

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -179,8 +179,8 @@ onfleetApi.workers.getByLocation(locationParams).then((results) => { /* ... */ }
 
 #### Peticiones POST
 Para crear un elemento de un recurso:
-```js{
-create({ data }});
+```js
+create({ data });
 ```
 
 ##### Ejemplos de `create()`

--- a/README.fr.md
+++ b/README.fr.md
@@ -182,7 +182,7 @@ onfleetApi.workers.getByLocation(locationParams).then((results) => { /* ... */ }
 #### Demandes POST
 Pour créer un document dans un noeud final:
 ```js
-create({ data }});
+create({ data });
 ```
 
 ##### Exemples de `create()`

--- a/README.md
+++ b/README.md
@@ -179,8 +179,8 @@ onfleetApi.workers.getByLocation(locationParams).then((results) => { /* ... */ }
 
 #### POST Requests
 To create a document within an endpoint:
-```js{
-create({ data }});
+```js
+create({ data });
 ```
 
 ##### Examples of `create()`


### PR DESCRIPTION
**Describe the solution**
On Readme files there is an extra curly bracket (}) for create method explanation. It was removed.

---

**Fixed**
* On Readme files, an extra curly bracket for create method explanation was removed.
