### PR TITLE
docs: Changed matchMetdata to matchMetadata on README.md files

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -212,7 +212,7 @@ onfleetApi.workers.setSchedule('<24_digit_ID>', { data });
 
 onfleetApi.teams.autoDispatch('<24_digit_ID>', { data });
 
-onfleetApi.<entity_name_pluralized>.matchMetdata({ data });
+onfleetApi.<entity_name_pluralized>.matchMetadata({ data });
 ```
 
 Para más información, podemos consultar la documentación sobre [`clone`](https://docs.onfleet.com/reference#clone-task), [`forceComplete`](https://docs.onfleet.com/reference#complete-task), [`batchCreate`](https://docs.onfleet.com/reference#create-tasks-in-batch), [`autoAssign`](https://docs.onfleet.com/reference#automatically-assign-list-of-tasks), [`setSchedule`](https://docs.onfleet.com/reference#set-workers-schedule). [`matchMetadata`](https://docs.onfleet.com/reference#querying-by-metadata) y [`autoDispatch`](https://docs.onfleet.com/reference#team-auto-dispatch).

--- a/README.fr.md
+++ b/README.fr.md
@@ -214,7 +214,7 @@ onfleetApi.workers.setSchedule('<24_digit_ID>', { data });
 
 onfleetApi.teams.autoDispatch('<24_digit_ID>', { data });
 
-onfleetApi.<entity_name_pluralized>.matchMetdata({ data });
+onfleetApi.<entity_name_pluralized>.matchMetadata({ data });
 ```
 
 Pour plus de détails, consultez notre documentation sur [`clone`](https://docs.onfleet.com/reference#clone-task), [`forceComplete`](https://docs.onfleet.com/reference#complete-task), [`batchCreate`](https://docs.onfleet.com/reference#create-tasks-in-batch), [`autoAssign`](https://docs.onfleet.com/reference#automatically-assign-list-of-tasks), [`setSchedule`](https://docs.onfleet.com/reference#set-workers-schedule), [`matchMetadata`](https://docs.onfleet.com/reference#querying-by-metadata), et [`autoDispatch`](https://docs.onfleet.com/reference#team-auto-dispatch).

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ onfleetApi.workers.setSchedule('<24_digit_ID>', { data });
 
 onfleetApi.teams.autoDispatch('<24_digit_ID>', { data });
 
-onfleetApi.<entity_name_pluralized>.matchMetdata({ data });
+onfleetApi.<entity_name_pluralized>.matchMetadata({ data });
 ```
 
 For more details, check our documentation on [`clone`](https://docs.onfleet.com/reference#clone-task), [`forceComplete`](https://docs.onfleet.com/reference#complete-task), [`batchCreate`](https://docs.onfleet.com/reference#create-tasks-in-batch), [`autoAssign`](https://docs.onfleet.com/reference#automatically-assign-list-of-tasks), [`setSchedule`](https://docs.onfleet.com/reference#set-workers-schedule), [`matchMetadata`](https://docs.onfleet.com/reference#querying-by-metadata), and [`autoDispatch`](https://docs.onfleet.com/reference#team-auto-dispatch).

--- a/README.zh-tw.md
+++ b/README.zh-tw.md
@@ -212,7 +212,7 @@ onfleetApi.workers.setSchedule('<24_digit_ID>', { data });
 
 onfleetApi.teams.autoDispatch('<24_digit_ID>', { data });
 
-onfleetApi.<entity_name_pluralized>.matchMetdata({ data });
+onfleetApi.<entity_name_pluralized>.matchMetadata({ data });
 ```
 
 參考資料：[`clone`](https://docs.onfleet.com/reference#clone-task), [`forceComplete`](https://docs.onfleet.com/reference#complete-task), [`batchCreate`](https://docs.onfleet.com/reference#create-tasks-in-batch), [`autoAssign`](https://docs.onfleet.com/reference#automatically-assign-list-of-tasks), [`setSchedule`](https://docs.onfleet.com/reference#set-workers-schedule), [`matchMetadata`](https://docs.onfleet.com/reference#querying-by-metadata), 以及[`autoDispatch`](https://docs.onfleet.com/reference#team-auto-dispatch)。


### PR DESCRIPTION

**Describe the solution**
Documentation on  README.md files had a typo with method matchMetadata which was changed from matchMetdata to matchMetadata

---

**Fixed**
- Documentation on  README.md files had a typo with method matchMetadata which was changed from matchMetdata to matchMetadata
