### PR TITLE
INT-398: Announce OSS releases on Slack automatically

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -32,3 +32,33 @@ jobs:
       - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  notify:
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: slackapi/slack-github-action@v1.18.0
+        with:
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":js: A new version of `node-onfleet` has been released: `${{ github.event.release.tag_name }}`"
+                  },
+                  "accessory": {
+                    "type": "button",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "See details"
+                    },
+                    "url": "${{ github.event.release.html_url }}"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -46,7 +46,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":js: A new version of `node-onfleet` has been released: `${{ github.event.release.tag_name }}`"
+                    "text": ":js: A new version of `node-onfleet` has been released: `${{ github.event.release.tag_name }}` :tada:"
                   },
                   "accessory": {
                     "type": "button",


### PR DESCRIPTION
**Describe the solution**
When creating an open-source release we want to announce it on the #internal-tools channel, automating what we currently do manually after each release.

---

**Added**

- Announce automatically a new open-source release on Slack channels