### PR TITLE
INT-805 Add custom headers to the Onfleet requests via node-wrapper

### DIFF
--- a/lib/onfleet.js
+++ b/lib/onfleet.js
@@ -27,6 +27,15 @@ resources.Webhooks = require('./resources/Webhooks');
  */
 
 class Onfleet {
+  get customHeaders() {
+    return this.headers;
+  }
+
+  set customHeaders(headers) {
+    this.headers = headers;
+    this.api.headers = { ...this.api.headers, ...this.customHeaders };
+  }
+
   constructor(
     apiKey,
     userTimeout,


### PR DESCRIPTION
**Describe the solution**
Added custom headers to all the requests.

---

**Added**
- the customHeaders property for the Onfleet class
- Once you set the custom headers, these are combined with the generated by the onfleet class.