### PR TITLE
[INT-1921][Node API Wrapper] Custom field support for node API wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.5] - 2024-08-09
+### Added
+- Added Custom field support for node API wrapper
+
 ## [1.3.4] - 2024-05-17
 ### Added
 - Added support for Worker's Route Delivery Manifest
@@ -124,6 +128,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release on npm
 
 [Unreleased]: https://github.com/onfleet/node-onfleet/compare/v1.3.0...HEAD
+[1.3.5]: https://github.com/onfleet/node-onfleet/compare/v1.3.4...v1.3.5
 [1.3.4]: https://github.com/onfleet/node-onfleet/compare/v1.3.3...v1.3.4
 [1.3.3]: https://github.com/onfleet/node-onfleet/compare/v1.3.2...v1.3.3
 [1.3.2]: https://github.com/onfleet/node-onfleet/compare/v1.3.1...v1.3.2

--- a/README.es.md
+++ b/README.es.md
@@ -116,6 +116,7 @@ Estas son las operaciones disponibles para cada endpoint:
 | [Teams](https://docs.onfleet.com/reference/teams) | get()<br />get(id)<br />getWorkerEta(id, obj)<br />getTasks(id) | create(obj)<br />autoDispatch(id, obj) | update(id, obj) | deleteOne(id) |
 | [Webhooks](https://docs.onfleet.com/reference/webhooks) | get() | create(obj) | x | deleteOne(id) |
 | [Workers](https://docs.onfleet.com/reference/workers) | get()<br />get(query)<br />get(id)<br />getByLocation(obj)<br />getSchedule(id)<br />getTasks(id) | create(obj)<br />setSchedule(id, obj)<br />matchMetadata(obj)<br />getDeliveryManifest(obj) | update(id, obj)<br />insertTask(id, obj) | deleteOne(id) |
+| [Custom Fields](https://docs.onfleet.com/reference/task-custom-fields) | get(modelName) | create(obj) | update(obj) | delete(obj) |
 
 #### Peticiones GET
 Para obtener todos los elementos disponibles en un recurso, éstas llamadas retornan un `Promise` con el arreglo de los resultados:

--- a/README.fr.md
+++ b/README.fr.md
@@ -119,6 +119,7 @@ Voici les opérations CRUD prises en charge pour chaque ordinateur d'extrémité
 | [Teams](https://docs.onfleet.com/reference#teams) | get()<br />get(id)<br />getWorkerEta(id, obj)<br />getTasks(id) | create(obj)<br />autoDispatch(id, obj) | update(id, obj) | deleteOne(id) |
 | [Webhooks](https://docs.onfleet.com/reference#webhooks) | get() | create(obj) | x | deleteOne(id) |
 | [Workers](https://docs.onfleet.com/reference#workers) | get()<br />get(query)<br />get(id)<br />getByLocation(obj)<br />getSchedule(id)<br />getTasks(id) | create(obj)<br />setSchedule(id, obj)<br />matchMetadata(obj)<br />getDeliveryManifest(obj) | update(id, obj)<br />insertTask(id, obj) | deleteOne(id) |
+| [Custom Fields](https://docs.onfleet.com/reference/task-custom-fields) | get(modelName) | create(obj) | update(obj) | delete(obj) |
 
 #### Demandes GET
 Pour obtenir tous les documents d'un noeud final, cela renvoie une `Promise` contenant un tableau de résultats:

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Here are the operations available for each entity:
 | [Teams](https://docs.onfleet.com/reference#teams) | get()<br />get(id)<br />getWorkerEta(id, obj)<br />getTasks(id) | create(obj)<br />autoDispatch(id, obj) | update(id, obj) | deleteOne(id) |
 | [Webhooks](https://docs.onfleet.com/reference#webhooks) | get() | create(obj) | x | deleteOne(id) |
 | [Workers](https://docs.onfleet.com/reference#workers) | get()<br />get(query)<br />get(id)<br />getByLocation(obj)<br />getSchedule(id)<br />getTasks(id) | create(obj)<br />setSchedule(id, obj)<br />matchMetadata(obj)<br />getDeliveryManifest(obj) | update(id, obj)<br />insertTask(id, obj) | deleteOne(id) |
+| [Custom Fields](https://docs.onfleet.com/reference/task-custom-fields) | get(modelName) | create(obj) | update(obj) | delete(obj) |
 
 #### GET Requests
 To get all the documents within an endpoint, this returns a `Promise` containing an array of results:

--- a/README.zh-tw.md
+++ b/README.zh-tw.md
@@ -116,6 +116,7 @@ onfleetApi.verifyKey();  // Returns a boolean
 | [Teams](https://docs.onfleet.com/reference/teams) | get()<br />get(id)<br />getWorkerEta(id, obj)<br />getTasks(id) | create(obj)<br />autoDispatch(id, obj) | update(id, obj) | deleteOne(id) |
 | [Webhooks](https://docs.onfleet.com/reference/webhooks) | get() | create(obj) | x | deleteOne(id) |
 | [Workers](https://docs.onfleet.com/reference/workers) | get()<br />get(query)<br />get(id)<br />getByLocation(obj)<br />getSchedule(id)<br />getTasks(id) | create(obj)<br />setSchedule(id, obj)<br />matchMetadata(obj)<br />getDeliveryManifest(obj) | update(id, obj)<br />insertTask(id, obj) | deleteOne(id) |
+| [Custom Fields](https://docs.onfleet.com/reference/task-custom-fields) | get(modelName) | create(obj) | update(obj) | delete(obj) |
 
 #### GET 請求
 展示所有資源的指令如下，回應的主體為包含一陣列的[`Promise`物件](https://developer.mozilla.org/zh-TW/docs/Web/JavaScript/Reference/Global_Objects/Promise):

--- a/lib/onfleet.js
+++ b/lib/onfleet.js
@@ -21,6 +21,7 @@ resources.Tasks = require('./resources/Tasks');
 resources.Teams = require('./resources/Teams');
 resources.Workers = require('./resources/Workers');
 resources.Webhooks = require('./resources/Webhooks');
+resources.CustomFields = require('./resources/CustomFields');
 
 /**
  * @desc Onfleet object initiates all the resources

--- a/lib/resources/CustomFields.js
+++ b/lib/resources/CustomFields.js
@@ -1,0 +1,33 @@
+const Resource = require('../Resource');
+
+/**
+ * @desc this class holds the CRUD methods allowed on the Custom Fields endpoint
+ */
+
+class CustomFields extends Resource {
+  constructor(api) {
+    super(api);
+    this.defineTimeout();
+    this.endpoints({
+      create: {
+        path: '/customFields',
+        method: 'POST',
+      },
+      get: {
+        path: '/customFields/:modelName',
+        altPath: '/customFields/task',
+        method: 'GET',
+      },
+      update: {
+        path: '/customFields',
+        method: 'PUT',
+      },
+      delete: {
+        path: '/customFields',
+        method: 'DELETE',
+      },
+    });
+  }
+}
+
+module.exports = CustomFields;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@onfleet/node-onfleet",
-  "version": "1.3.3",
+  "version": "1.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onfleet/node-onfleet",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Onfleet's Node.js API Wrapper Package",
   "main": "index.js",
   "scripts": {

--- a/test/response.js
+++ b/test/response.js
@@ -224,4 +224,32 @@ module.exports = {
   ],
     totalDistance: null
   },
+  getCustomFields: {
+    fields: [
+      {
+        "description": "this is a test",
+        "asArray": false,
+        "visibility": [
+          "admin",
+          "api",
+          "worker"
+        ],
+        "editability": [
+          "admin",
+          "api"
+        ],
+        "key": "test",
+        "name": "test",
+        "type": "single_line_text_field",
+        "contexts": [
+          {
+            "isRequired": false,
+            "conditions": [],
+            "name": "save"
+          }
+        ],
+        "value": "order 123"
+      }
+    ]
+  }
 };

--- a/test/response.js
+++ b/test/response.js
@@ -224,6 +224,7 @@ module.exports = {
   ],
     totalDistance: null
   },
+  createCustomFields: 200,
   getCustomFields: {
     fields: [
       {

--- a/test/test.js
+++ b/test/test.js
@@ -79,7 +79,7 @@ describe('Utility function testing - Auth test returns 200 ok', () => {
     return util.authenticate({
       baseUrl: 'https://onfleet.com/api/v2',
       headers: {
-        authorization: 'Basic some_token',
+        authorization: 'Basic c94aa851ae39d4e8c61b79fb7658e6e3',
       },
     })
       .then((res) => {
@@ -160,6 +160,9 @@ describe('HTTP Request testing', () => {
     nock(baseUrl)
       .post((uri) => uri.includes('integrations'))
       .reply(200, response.getManifestProvider);
+    nock(baseUrl)
+      .get((uri) => uri.includes('customFields/task'))
+      .reply(200, response.getCustomFields);
   });
   it('Get function', () => {
     return onfleet.administrators.get()
@@ -274,6 +277,13 @@ describe('HTTP Request testing', () => {
         expect(typeof res).to.equal('object');
         assert.equal(res.manifestDate, 1694199600000);
         assert.equal(res.turnByTurn.length, 1);
+      });
+  });
+  it('Get custom fields', () => {
+    return onfleet.customfields.get()
+      .then((res) => {
+        expect(typeof res).to.equal('object');
+        assert.equal(res.fields.length, 1);
       });
   });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -79,7 +79,7 @@ describe('Utility function testing - Auth test returns 200 ok', () => {
     return util.authenticate({
       baseUrl: 'https://onfleet.com/api/v2',
       headers: {
-        authorization: 'Basic c94aa851ae39d4e8c61b79fb7658e6e3',
+        authorization: 'Basic some_token',
       },
     })
       .then((res) => {

--- a/test/test.js
+++ b/test/test.js
@@ -48,6 +48,34 @@ const deliveryManifestObject = {
   endDate: '1455072025000'
 };
 
+const createCustomField = {
+  model: 'Task',
+  field: [{
+    "description": "this is a test",
+    "asArray": false,
+    "visibility": [
+      "admin",
+      "api",
+      "worker"
+    ],
+    "editability": [
+      "admin",
+      "api"
+    ],
+    "key": "test",
+    "name": "test",
+    "type": "single_line_text_field",
+    "contexts": [
+      {
+        "isRequired": false,
+        "conditions": [],
+        "name": "save"
+      }
+    ],
+    "value": "order 123"
+  }]
+}
+
 chai.should();
 chai.use(chaiAsPromised);
 
@@ -161,8 +189,11 @@ describe('HTTP Request testing', () => {
       .post((uri) => uri.includes('integrations'))
       .reply(200, response.getManifestProvider);
     nock(baseUrl)
-      .get((uri) => uri.includes('customFields/task'))
+      .get((uri) => uri.includes('customFields'))
       .reply(200, response.getCustomFields);
+    nock(baseUrl)
+      .post((uri) => uri.includes('customFields'))
+      .reply(200, response.createCustomFields);
   });
   it('Get function', () => {
     return onfleet.administrators.get()
@@ -284,6 +315,12 @@ describe('HTTP Request testing', () => {
       .then((res) => {
         expect(typeof res).to.equal('object');
         assert.equal(res.fields.length, 1);
+      });
+  });
+  it('Create custom field', () => {
+    return onfleet.customfields.create(createCustomField)
+      .then((res) => {
+        assert.equal(res, 200);
       });
   });
 });


### PR DESCRIPTION
<!---
Loosely inspired by https://keepachangelog.com/en/1.1.0/.

Please add items to their respective section and delete empty sections.
- Added: for new features
- Changed: for changes in existing functionality
- Deprecated: for soon-to-be removed features
- Removed: for now removed features
- Fixed: for any bug fixes
- Security: in case of vulnerabilities
Ideally, each item here will be added into the upcoming release.

DO NOT post internal Onfleet links (e.g. Jira/Confluence) –this is a public space.
-->

**Describe the solution**
Custom field support for node API wrapper. Added a new resource for CustomFields that supports GET - CREATE- UPDATE - DELETE operations and update testing files.
https://onfleet.atlassian.net/browse/INT-1921
https://docs.onfleet.com/reference/task-custom-fields

---

**Added**
Added new resource with CustomFields endpoints
Update readme files
The test file was updated

**Changed**

**Deprecated**

**Removed**

**Fixed**

**Security**